### PR TITLE
Fix: Fix repo link typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ internal use.
   
   
 You can find a collection of personal config/workflow files on my  
-profile repo [elliotxjones/elliotxjones](https://github.com/elliotxjones/elliotxjone).  
+profile repo [elliotxjones/elliotxjones](https://github.com/elliotxjones/elliotxjones).  
   
 I use these daily in WSL running Debian for work, but most of these  
 I already use personally on my pc running Gentoo. Keeping them here  


### PR DESCRIPTION
Fixes repo link typo in README.md as it currently redirects to 404.